### PR TITLE
fix pylint warnings directly disabling their checks

### DIFF
--- a/bobtemplates/eea/addon/+package.namespace+/+package.namespace2+/+package.name+/tests/base.py.bob
+++ b/bobtemplates/eea/addon/+package.namespace+/+package.namespace2+/+package.name+/tests/base.py.bob
@@ -15,6 +15,7 @@ class EEAFixture(PloneSandboxLayer):
     def setUpZope(self, app, configurationContext):
         """ Setup Zope
         """
+        # pylint: disable=C0415
         import {{{ package.dottedname }}}
         self.loadZCML(package={{{ package.dottedname }}})
         z2.installProduct(app, '{{{ package.dottedname }}}')

--- a/bobtemplates/eea/addon/setup.py.bob
+++ b/bobtemplates/eea/addon/setup.py.bob
@@ -6,8 +6,11 @@ from setuptools import setup, find_packages
 
 NAME = '{{{ package.dottedname }}}'
 PATH = NAME.split('.') + ['version.txt']
+
+# pylint: disable=R1732
 VERSION = open(join(*PATH)).read().strip()
 
+# pylint: disable=R1732
 setup(
     name=NAME,
     version=VERSION,


### PR DESCRIPTION
pylint is very picky with some warnings, adding these ignore statements, a base addon created with this template at least passes the basic tests that Jenkins does